### PR TITLE
Pandas 0.24 Compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-pandas==0.22.0
+pandas
 cvxopt
-scipy
+scipy==1.2
 matplotlib
-pandas-datareader
-statsmodels
+pandas-datareader>=0.7.0
+statsmodels>=0.9.0
 scikit-learn
+seaborn

--- a/universal/tools.py
+++ b/universal/tools.py
@@ -2,8 +2,6 @@ import pandas as pd
 import numpy as np
 import scipy.optimize as optimize
 from scipy.special import betaln
-from pandas.stats.moments import rolling_mean as rolling_m
-from pandas.stats.moments import rolling_corr
 import matplotlib.pyplot as plt
 from time import time
 from datetime import datetime
@@ -251,7 +249,7 @@ def rolling_corr(x, y, **kwargs):
     def rolling(dataframe, *args, **kwargs):
         ret = dataframe.copy()
         for col in ret:
-            ret[col] = rolling_m(ret[col], *args, **kwargs)
+            ret[col] = ret[col].rolling(*args, **kwargs).mean()
         return ret
 
     n, k = x.shape
@@ -267,7 +265,8 @@ def rolling_corr(x, y, **kwargs):
         for j, col_y in enumerate(y):
             DX = EX2[col_x] - EX[col_x] ** 2
             DY = EY2[col_y] - EY[col_y] ** 2
-            RXY[:, i, j] = rolling_m(x[col_x] * y[col_y], **kwargs) - EX[col_x] * EY[col_y]
+            product = x[col_x] * y[col_y]
+            RXY[:, i, j] = product.rolling(**kwargs).mean() - EX[col_x] * EY[col_y]
             RXY[:, i, j] = RXY[:, i, j] / np.sqrt(DX * DY)
 
     return RXY, EX.values


### PR DESCRIPTION
Fix #20. 

This makes universal-portfolios compatible with pandas 0.24.

Note that it:
- Requires pandas-datareader 0.7
- Requires statsmodels 0.9.0. statsmodels 0.9.0 is not compatible with latest scipy (1.3), so I hard-coded the scipy version to 1.2.  The forthcoming vesrion of statsmodels 0.10.0, does support scipy 1.3.  See statsmodels/statsmodels#5747

The tests pass.