### PR TITLE
On-line portfolios.ipynb: use non-deprecated args to pandas.DataFrame.drop(..)

### DIFF
--- a/On-line portfolios.ipynb
+++ b/On-line portfolios.ipynb
@@ -269,7 +269,7 @@
     "most_profitable = result.equity_decomposed.iloc[-1].idxmax()\n",
     "\n",
     "# rerun an algorithm on data without it\n",
-    "result_without = algo.run(data.drop([most_profitable], 1))\n",
+    "result_without = algo.run(data.drop(columns=[most_profitable]))\n",
     "\n",
     "# and print results\n",
     "print(result_without.summary())\n",


### PR DESCRIPTION
This commit updates the call to `pandas.DataFrame.drop(..)` to avoid this current (`origin/master`) warning  (which becomes an error in later versions of pandas)u:

```
/tmp/ipykernel_49/729256678.py:5: FutureWarning: In a future version of pandas all arguments of DataFrame.drop except for the argument 'labels' will be keyword-only.
  result_without = algo.run(data.drop([most_profitable], 1))
```