### PR TITLE
Bug fix: Added rprt to __init__.py

### DIFF
--- a/universal/algos/__init__.py
+++ b/universal/algos/__init__.py
@@ -16,6 +16,7 @@ from .olmar import OLMAR
 from .ons import ONS
 from .pamr import PAMR
 from .rmr import RMR
+from .rprt import RPRT
 from .tco import TCO1, TCO2
 from .up import UP
 from .wmamr import WMAMR


### PR DESCRIPTION
The algos package __init__.py has all the algorithms imported except for RPRT.
This pull request adds RPRT to the __init__.py