### PR TITLE
Fix rolling corr for anticor algorithm

### DIFF
--- a/universal/tools.py
+++ b/universal/tools.py
@@ -298,7 +298,8 @@ def rolling_corr(x, y, **kwargs):
             DY = EY2[col_y] - EY[col_y] ** 2
             product = x[col_x] * y[col_y]
             RXY[:, i, j] = product.rolling(**kwargs).mean() - EX[col_x] * EY[col_y]
-            RXY[:, i, j] = RXY[:, i, j] / np.sqrt(DX * DY)
+            if np.sqrt(DX * DY) != 0 : RXY[:, i, j] = RXY[:, i, j] / np.sqrt(DX * DY)
+            else: RXY[:, i, j] = RXY[:, i, j]*0
 
     return RXY, EX.values
 


### PR DESCRIPTION
Stumbled upon NAN values while using the ANTICOR implementation, the original paper states that :

(page 6)
We note that if sigma1(i) (respectively,
sigma2(j)) is zero over some window then the growth rate of stock i during the second last window (respectively, stock j during the last window) is constant during this window. For sufficiently large windows of time constant growth of any stock i is unlikely. However, in this unlikely case we choose not to move money into or out of such a stock i.12.

To make the implementation take this detail into account, i changed the calculation for the correlation matrix to give 0 when a stock has no variance over a time window, this should fix the problem.  I haven't checked if this method is used outside of anticor, but it should avoid nan values anyways.