### PR TITLE
Anticor Bug fix for undefined correlation

### DIFF
--- a/universal/algos/anticor.py
+++ b/universal/algos/anticor.py
@@ -68,10 +68,11 @@ class Anticor(Algo):
                                 claim[i, j] += abs(M[j, j])
 
                 # calculate transfer
+                claim = np.nan_to_num(claim) #correlation can be nan
                 transfer = claim * 0.0
                 for i in range(m):
                     total_claim = sum(claim[i, :])
-                    if total_claim != 0:
+                    if total_claim != 0 and not np.isnan(total_claim).any(): #transfer should never be nan
                         transfer[i, :] = weights[t, i] * claim[i, :] / total_claim
 
                 # update weights


### PR DESCRIPTION
Stumbled upon NAN values while using the ANTICOR implementation, the original paper states that :

(page 6)
We note that if sigma1(i) (respectively,
sigma2(j)) is zero over some window then the growth rate of stock i during the second last window (respectively, stock j during the last window) is constant during this window. For sufficiently large windows of time constant growth of any stock i is unlikely. However, in this unlikely case we choose not to move money into or out of such a stock i.12.

To make the implementation take this detail into account, i simply skipped transfers that could have NAN values from an undefined correlation.