### PR TITLE
Pin gh-action-pypi-publish to its commit SHA, not the tag object

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,4 +72,7 @@ jobs:
           rm -rf dist
           uv build
 
-      - uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
+      # Docker action: the ref must be the commit SHA, since GitHub pulls
+      # ghcr.io/pypa/gh-action-pypi-publish:<ref> and no image is published for
+      # the annotated tag's object SHA.
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
The publish job on the #137 merge failed with `manifest unknown` pulling `ghcr.io/pypa/gh-action-pypi-publish:a892a5a6...`. One-line fix: pin the action to its **commit** SHA.

*Skim — one line changed, plus a comment explaining why it can't be the tag SHA.*

## How it works

`v1.14.2` is an annotated tag, so `GET /git/ref/tags/v1.14.2` returns the *tag object's* SHA (`a892a5a6…`), not the commit it points at (`dc37677b…`). I pinned the former.

That distinction is invisible for JavaScript actions, which is why `actions/checkout` and `astral-sh/setup-uv` worked — both use lightweight tags, so their ref SHA *is* a commit. `gh-action-pypi-publish` is a **Docker** action, so GitHub pulls `ghcr.io/pypa/gh-action-pypi-publish:<ref>`, and pypa publishes images per commit, never for a tag object.

Verified against the registry this time rather than assuming:

```
dc37677b2e1c… (commit)     -> HTTP 200, image exists
a892a5a61159… (tag object) -> HTTP 404
```

## Verified

Nothing was published by the failed run. It died on the image pull, which is step 5 of the publish job — `check` (version gate), `checkout`, `setup-uv` and `Build` had all succeeded, and the failure came *before* the OIDC exchange. `universal-portfolios 0.4.17` is still 404 on PyPI; latest published is 0.4.16.

That also means the trusted-publisher configuration has still never been exercised. If it's misconfigured, the next run fails at the OIDC step — again before any upload, so still no risk of a partial release.

## After merging

This changes only the workflow file, and `publish.yml` filters on `paths: [pyproject.toml]`, so merging will **not** auto-trigger a publish. 0.4.17 needs a manual kick:

```
gh workflow run publish.yml
```

`workflow_dispatch` short-circuits the version check and forces a publish, so no further version bump is needed.
